### PR TITLE
boj 21966 (중략)

### DIFF
--- a/src/string/Boj21966.java
+++ b/src/string/Boj21966.java
@@ -1,0 +1,34 @@
+package string;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Boj21966 {
+    private static StringBuffer sb = new StringBuffer();
+    private static int N;
+
+    private static void func() {
+        if (sb.length() > 25) {
+            if (sb.substring(11, sb.length() - 11).split("\\.").length > 1) {
+                sb.replace(9, sb.length() - 10, "......");
+            } else {
+                sb.replace(11, sb.length() - 11, "...");
+            }
+        }
+
+        System.out.println(sb);
+    }
+
+    private static void input() throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        sb.append(br.readLine());
+    }
+
+    public static void main(String[] args) throws Exception {
+        input();
+        func();
+    }
+}


### PR DESCRIPTION
## 알고리즘 분류
string

## 풀이 방법
1. 문자열의 길이가 25이하면 그대로 출력한다.
2. 문자열의 길이가 25보다 크면 앞, 뒤에서 11글자를 뺀 나머지 부분을 확인한다.
   + 나머지 문자열에 `.` 기준 split 했을 때 length가 1보다 크면 앞 9글자, 뒤 10글자를 제외하고 `......`으로 대체한다.
   + length가 1이면 앞, 뒤 11글자를 제외하고 `...`으로 대체한다.
3. 변환된 문자열을 출력한다.
